### PR TITLE
[generate] Replace org_id with generic hub_dataset_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ ENV/
 
 # Project specific
 results/
+data/

--- a/generate/README.md
+++ b/generate/README.md
@@ -71,8 +71,17 @@ For locally deployed models using SGLang, you can use the provided scripts:
 For HPC environments with SLURM, use `run_ioi_slurm.py` to evaluate open models:
 
 ```bash
-python run_ioi_slurm.py --model "MODEL_PATH" --concurrency 30 --startup_delay 7200 --logs_dir "DIR_FOR_OUTPUT_LOGS" --slurm_dir "DIR_FOR_SLUR_SCRIPT" --uv_env "PATH_TO_UV_ENV" --eval_args "--org_id YOUR_ORG_ID"
+python run_ioi_slurm.py --model "MODEL_PATH" --concurrency 30 --startup_delay 7200 --logs_dir "DIR_FOR_OUTPUT_LOGS" --slurm_dir "DIR_FOR_SLUR_SCRIPT" --uv_env "PATH_TO_UV_ENV"
 ```
+
+By default, this will push the results to a Hub dataset under your namespace with repo ID `{hub_user}/ioi-eval-sglang_{model}`. Use the `--eval_args` to specify the Hub dataset ID as follows:
+
+```shell
+python run_ioi_slurm.py --model "MODEL_PATH" --concurrency 30 --startup_delay 7200 --logs_dir "DIR_FOR_OUTPUT_LOGS" --slurm_dir "DIR_FOR_SLUR_SCRIPT" --uv_env "PATH_TO_UV_ENV" --eval_args "--hub_dataset_id {dataset_id}"
+```
+
+> [!NOTE]
+> The `--eval_args` flag can also be used to pass other arguments to the `evaluate.py` script.
 
 ## Output
 

--- a/generate/evaluate.py
+++ b/generate/evaluate.py
@@ -16,14 +16,14 @@ import aiofiles
 from litellm.utils import ModelResponse
 
 class IOIEvaluator:
-    def __init__(self, org_id: str, model_id: str, api_base: Optional[str] = None,  subset: Optional[str] = None,
+    def __init__(self, model_id: str, api_base: Optional[str] = None,  subset: Optional[str] = None,
                  num_generations: int = 50, num_retries: int = 10, 
                  concurrency: int = 10, num_problems: Optional[int] = None, 
                  last_subtask: bool = False, dry_run: bool = False,
                  override: bool = False, model_postfix: Optional[str] = None,
                  revision: Optional[str] = None, timeout: Optional[int] = 600,
-                 use_requests: bool = False, max_tokens: Optional[int] = None):
-        self.org_id = org_id
+                 use_requests: bool = False, max_tokens: Optional[int] = None, hub_dataset_id: Optional[str] = None):
+        self.hub_dataset_id = hub_dataset_id
         self.model_id = model_id
         self.api_base = api_base
         self.subset = subset
@@ -96,7 +96,7 @@ class IOIEvaluator:
         results_dfs = []
         
         # Try loading from Hub
-        repo_name = f"{self.org_id}/{self.get_model_name()}"
+        repo_name = self.hub_dataset_id if self.hub_dataset_id is not None else self.get_model_name()
         try:
             logger.info(f"Attempting to load previous results from HuggingFace Hub: {repo_name}")
             dataset = load_dataset(repo_name, split="train")
@@ -593,8 +593,9 @@ int main() {
                 model_name = self.get_model_name()
                 
                 try:
-                    output_dataset.push_to_hub(f"{self.org_id}/{model_name}")
-                    logger.info(f"Pushed to hub: {self.org_id}/{model_name}")
+                    hub_dataset_id = self.hub_dataset_id if self.hub_dataset_id is not None else model_name
+                    output_dataset.push_to_hub(hub_dataset_id)
+                    logger.info(f"Pushed to hub: {hub_dataset_id}")
                 except Exception as e:
                     logger.error(f"Failed to push to hub: {str(e)}")
             else:
@@ -644,7 +645,6 @@ def main():
     
     import argparse
     parser = argparse.ArgumentParser(description="Evaluate LLMs on IOI problems")
-    parser.add_argument("--org_id", required=True, help="Organization ID")
     parser.add_argument("--model_id", required=True, help="Model ID")
     parser.add_argument("--api_base", help="API base URL for the model")
     parser.add_argument("--subset", default="test", help="IOI subset to generate solutions for (train or test)")
@@ -660,10 +660,10 @@ def main():
     parser.add_argument("--timeout", type=int, default=600, help="Timeout for the LLM call")
     parser.add_argument("--use_requests", action="store_true", default=False, help="Use requests instead of litellm")
     parser.add_argument("--max_tokens", type=int, default=None, help="Max tokens")
+    parser.add_argument("--hub_dataset_id", type=str, default=None, help="Hub dataset ID to push results to. If `None`, will push results to user's namespace.")
     args = parser.parse_args()
 
     evaluator = IOIEvaluator(
-        org_id=args.org_id,
         model_id=args.model_id,
         api_base=args.api_base,
         subset=args.subset,
@@ -678,7 +678,8 @@ def main():
         revision=args.revision,
         timeout=args.timeout,
         use_requests=args.use_requests,
-        max_tokens=args.max_tokens
+        max_tokens=args.max_tokens,
+        hub_dataset_id=args.hub_dataset_id
     )
     asyncio.run(evaluator.run_evaluation())
 

--- a/generate/evaluate.py
+++ b/generate/evaluate.py
@@ -62,7 +62,7 @@ class IOIEvaluator:
             logger.warning("Running in dry-run mode - no actual LLM calls will be made")
 
         # Create results directory
-        self.model_dir = Path("results") / self.get_model_name()
+        self.model_dir = Path("results") / self.get_model_name() if self.hub_dataset_id is None else Path("results") / self.hub_dataset_id
         self.model_dir.mkdir(parents=True, exist_ok=True)
         
         # File path for the single JSONL file

--- a/generate/run_ioi_slurm.py
+++ b/generate/run_ioi_slurm.py
@@ -9,7 +9,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TP = 16
+DEFAULT_TP = 8
 MAX_CTX_LENGTH = None
 
 MODEL_CONFIGS = {}

--- a/generate/run_ioi_slurm.py
+++ b/generate/run_ioi_slurm.py
@@ -14,9 +14,9 @@ MAX_CTX_LENGTH = None
 
 MODEL_CONFIGS = {}
 
-LOGS_DIR = "/fsx/hynek_kydlicek/logs/ioi-eval"
-SLURM_SCRIPT_DIR = "/fsx/hynek_kydlicek/slurm/ioi-eval/output"
-UV_ENV = "/fsx/hynek_kydlicek/projects/ioi-leaderboard/ioi-eval"
+LOGS_DIR = "/fsx/lewis/git/hf/ioi/logs"
+SLURM_SCRIPT_DIR = "/fsx/lewis/git/hf/ioi/data"
+UV_ENV = "/fsx/lewis/git/hf/ioi/ioi"
 
 
 def get_concurrency(model_name: str, concurrency: int) -> int:
@@ -139,7 +139,7 @@ export GLOO_SOCKET_IFNAME="enp71s0"
 export NCCL_SOCKET_IFNAME="enp71s0"
 
 # Evaluation script path
-EVAL_SCRIPT_PATH="/fsx/hynek_kydlicek/projects/ioi/generate/evaluate.py"
+EVAL_SCRIPT_PATH="/fsx/lewis/git/hf/ioi/generate/evaluate.py"
 
 module load cuda/12.4
 source ~/.bashrc

--- a/generate/run_ioi_slurm.py
+++ b/generate/run_ioi_slurm.py
@@ -14,9 +14,9 @@ MAX_CTX_LENGTH = None
 
 MODEL_CONFIGS = {}
 
-LOGS_DIR = "/fsx/lewis/git/hf/ioi/logs"
-SLURM_SCRIPT_DIR = "/fsx/lewis/git/hf/ioi/data"
-UV_ENV = "/fsx/lewis/git/hf/ioi/ioi"
+LOGS_DIR = "/fsx/hynek_kydlicek/logs/ioi-eval"
+SLURM_SCRIPT_DIR = "/fsx/hynek_kydlicek/slurm/ioi-eval/output"
+UV_ENV = "/fsx/hynek_kydlicek/projects/ioi-leaderboard/ioi-eval"
 
 
 def get_concurrency(model_name: str, concurrency: int) -> int:
@@ -139,7 +139,7 @@ export GLOO_SOCKET_IFNAME="enp71s0"
 export NCCL_SOCKET_IFNAME="enp71s0"
 
 # Evaluation script path
-EVAL_SCRIPT_PATH="/fsx/lewis/git/hf/ioi/generate/evaluate.py"
+EVAL_SCRIPT_PATH="/fsx/hynek_kydlicek/projects/ioi/generate/evaluate.py"
 
 module load cuda/12.4
 source ~/.bashrc


### PR DESCRIPTION
This PR replaces the `--org_id` argument with `--hub_dataset_id` so that users can customise the repo ID of results from generation. This is particularly useful when doing repeated runs and one wants to store the results in separate repos.

Note that an alternative would be to retain `--org_id` and allow users to push each run to separate subsets of the same dataset. Happy to implement that variant if preferred